### PR TITLE
1.0.2

### DIFF
--- a/Either/Info.plist
+++ b/Either/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
No code changes from 1.0.1, but there’s a slight difference to the build:
- we share a scheme for building
- it no longer builds the tests when running or analyzing

I hope this will correct issues building from Carthage.
