### PR TITLE
@noescape

### DIFF
--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -30,7 +30,7 @@ public enum Either<T, U>: EitherType, Printable {
 	// MARK: API
 
 	/// Returns the result of applying `f` to the value of `Left`, or `g` to the value of `Right`.
-	public func either<Result>(#ifLeft: T -> Result, ifRight: U -> Result) -> Result {
+	public func either<Result>(@noescape #ifLeft: T -> Result, @noescape ifRight: U -> Result) -> Result {
 		switch self {
 		case let .Left(x):
 			return ifLeft(x.value)
@@ -40,7 +40,7 @@ public enum Either<T, U>: EitherType, Printable {
 	}
 
 	/// Maps `Right` instances with `f`, and returns `Left` instances as-is.
-	public func map<V>(f: U -> V) -> Either<T, V> {
+	public func map<V>(@noescape f: U -> V) -> Either<T, V> {
 		return either(ifLeft: Either<T, V>.left, ifRight: { .right(f($0)) })
 	}
 
@@ -75,7 +75,7 @@ public enum Either<T, U>: EitherType, Printable {
 /// If `left` is `Either.Right`, extracts its value and passes it to `right`, returning the result; otherwise transforms `left` into the return type.
 ///
 /// This is the bind or flat map operator, and is useful for chaining computations taking some parameter and returning an `Either`.
-public func >>- <T, U, V> (left: Either<T, U>, right: U -> Either<T, V>) -> Either<T, V> {
+public func >>- <T, U, V> (left: Either<T, U>, @noescape right: U -> Either<T, V>) -> Either<T, V> {
 	return left.either(ifLeft: Either<T, V>.left, ifRight: right)
 }
 

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -79,11 +79,11 @@ public enum Either<T, U>: EitherType, Printable {
 
 // MARK: - Free functions
 
-/// If `left` is `Either.Right`, extracts its value and passes it to `right`, returning the result; otherwise transforms `left` into the return type.
+/// If `left` is `Either.Right`, extracts its value and passes it to `transform`, returning the result; otherwise transforms `either` into the return type.
 ///
 /// This is the bind or flat map operator, and is useful for chaining computations taking some parameter and returning an `Either`.
-public func >>- <T, U, V> (left: Either<T, U>, @noescape right: U -> Either<T, V>) -> Either<T, V> {
-	return left.either(ifLeft: Either<T, V>.left, ifRight: right)
+public func >>- <T, U, V> (either: Either<T, U>, @noescape transform: U -> Either<T, V>) -> Either<T, V> {
+	return either.flatMap(transform)
 }
 
 

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -30,36 +30,42 @@ public enum Either<T, U>: EitherType, Printable {
 	// MARK: API
 
 	/// Returns the result of applying `f` to the value of `Left`, or `g` to the value of `Right`.
-	public func either<V>(f: T -> V, _ g: U -> V) -> V {
+	public func either<Result>(#ifLeft: T -> Result, ifRight: U -> Result) -> Result {
 		switch self {
 		case let .Left(x):
-			return f(x.value)
+			return ifLeft(x.value)
 		case let .Right(x):
-			return g(x.value)
+			return ifRight(x.value)
 		}
 	}
 
 	/// Maps `Right` instances with `f`, and returns `Left` instances as-is.
 	public func map<V>(f: U -> V) -> Either<T, V> {
-		return either(Either<T, V>.left, f >>> Either<T, V>.right)
+		return either(ifLeft: Either<T, V>.left, ifRight: { .right(f($0)) })
 	}
 
 
 	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
 	public var left: T? {
-		return either(unit, const(nil))
+		return either(
+			ifLeft: unit,
+			ifRight: const(nil))
 	}
 
 	/// Returns the value of `Right` instances, or `nil` for `Left` instances.
 	public var right: U? {
-		return either(const(nil), unit)
+		return either(
+			ifLeft: const(nil),
+			ifRight: unit)
 	}
 
 
 	// MARK: Printable
 
 	public var description: String {
-		return either({ ".Left(\($0))"}, { ".Right(\($0))" })
+		return either(
+			ifLeft: { ".Left(\($0))"},
+			ifRight: { ".Right(\($0))" })
 	}
 }
 
@@ -70,7 +76,7 @@ public enum Either<T, U>: EitherType, Printable {
 ///
 /// This is the bind or flat map operator, and is useful for chaining computations taking some parameter and returning an `Either`.
 public func >>- <T, U, V> (left: Either<T, U>, right: U -> Either<T, V>) -> Either<T, V> {
-	return left.either(Either<T, V>.left, right)
+	return left.either(ifLeft: Either<T, V>.left, ifRight: right)
 }
 
 

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -41,7 +41,7 @@ public enum Either<T, U>: EitherType, Printable {
 
 	/// Maps `Right` values with `transform`, and re-wraps `Left` values.
 	public func map<V>(@noescape transform: U -> V) -> Either<T, V> {
-		return either(ifLeft: Either<T, V>.left, ifRight: { .right(transform($0)) })
+		return flatMap { .right(transform($0)) }
 	}
 
 	/// Returns the result of applying `transform` to `Right` values, or re-wrapping `Left` values.

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -39,9 +39,9 @@ public enum Either<T, U>: EitherType, Printable {
 		}
 	}
 
-	/// Maps `Right` instances with `f`, and returns `Left` instances as-is.
-	public func map<V>(@noescape f: U -> V) -> Either<T, V> {
-		return either(ifLeft: Either<T, V>.left, ifRight: { .right(f($0)) })
+	/// Maps `Right` values with `transform`, and re-wraps `Left` values.
+	public func map<V>(@noescape transform: U -> V) -> Either<T, V> {
+		return either(ifLeft: Either<T, V>.left, ifRight: { .right(transform($0)) })
 	}
 
 

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -44,6 +44,13 @@ public enum Either<T, U>: EitherType, Printable {
 		return either(ifLeft: Either<T, V>.left, ifRight: { .right(transform($0)) })
 	}
 
+	/// Returns the result of applying `transform` to `Right` values, or re-wrapping `Left` values.
+	public func flatMap<V>(@noescape transform: U -> Either<T, V>) -> Either<T, V> {
+		return either(
+			ifLeft: Either<T, V>.left,
+			ifRight: transform)
+	}
+
 
 	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
 	public var left: T? {

--- a/Either/EitherType.swift
+++ b/Either/EitherType.swift
@@ -16,7 +16,7 @@ public protocol EitherType {
 	static func right(value: Right) -> Self
 
 	/// Returns the result of applying `f` to `Left` values, or `g` to `Right` values.
-	func either<Result>(f: Left -> Result, _ g: Right -> Result) -> Result
+	func either<Result>(#ifLeft: Left -> Result, ifRight: Right -> Result) -> Result
 }
 
 
@@ -24,7 +24,9 @@ public protocol EitherType {
 
 /// Equality (tho not `Equatable`) over `EitherType` where `Left` & `Right` : `Equatable`.
 public func == <E: EitherType where E.Left: Equatable, E.Right: Equatable> (lhs: E, rhs: E) -> Bool {
-	return lhs.either({ $0 == rhs.either(unit, const(nil)) }, { $0 == rhs.either(const(nil), unit) })
+	return lhs.either(
+		ifLeft: { $0 == rhs.either(ifLeft: unit, ifRight: const(nil)) },
+		ifRight: { $0 == rhs.either(ifLeft: const(nil), ifRight: unit) })
 }
 
 

--- a/Either/EitherType.swift
+++ b/Either/EitherType.swift
@@ -16,7 +16,7 @@ public protocol EitherType {
 	static func right(value: Right) -> Self
 
 	/// Returns the result of applying `f` to `Left` values, or `g` to `Right` values.
-	func either<Result>(#ifLeft: Left -> Result, ifRight: Right -> Result) -> Result
+	func either<Result>(@noescape #ifLeft: Left -> Result, @noescape ifRight: Right -> Result) -> Result
 }
 
 


### PR DESCRIPTION
- Marks everything that can be as `@noescape`.
- Adds labels to `.either`.

This breaks backwards-compatibility, but Swift 1.2 already did that, so that’s probably ok.