### PR TITLE
Higher order equality

### DIFF
--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -67,6 +67,7 @@ public enum Either<T, U>: EitherType, Printable {
 	}
 
 
+	/// Given equality functions for `T` and `U`, returns an equality function for `Either<T, U>`.
 	public static func equals(#left: (T, T) -> Bool, right: (U, U) -> Bool)(_ a: Either<T, U>, _ b: Either<T, U>) -> Bool {
 		return
 			(a.left &&& b.left).map(left)

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -67,6 +67,14 @@ public enum Either<T, U>: EitherType, Printable {
 	}
 
 
+	public static func equals(#left: (T, T) -> Bool, right: (U, U) -> Bool)(_ a: Either<T, U>, _ b: Either<T, U>) -> Bool {
+		return
+			(a.left &&& b.left).map(left)
+		??	(a.right &&& b.right).map(right)
+		??	false
+	}
+
+
 	// MARK: Printable
 
 	public var description: String {


### PR DESCRIPTION
Adds a higher order equality function for computing equality functions for `Either<T, U>` given equality functions for `T` and `U` respectively.