### PR TITLE
Update precedence of `>>-` to match Runes 2.0.0

### DIFF
--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -103,7 +103,7 @@ infix operator >>- {
 	associativity left
 
 	// Higher precedence than function application, but lower than function composition.
-	precedence 150
+	precedence 100
 }
 
 


### PR DESCRIPTION
In support of https://github.com/robrix/Madness/pull/86.

See also https://github.com/thoughtbot/Runes/pull/30.