### PR TITLE
Add argument labels to either() example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Extracting the value:
 
 ```swift
 // Unwrap:
-let value = left.either({ x in x }, { string in countElements(string) })
+let value = left.either(ifLeft: { x in x }, ifRight: { string in countElements(string) })
 ```
 
 Representing success/failure:


### PR DESCRIPTION
Looks like the readme wasn't updated after 1b67d43ea0a97a632ab176219b1cd80114785c1d