### PR TITLE
Add `mapLeft` and `flatMapLeft`

### DIFF
--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -51,6 +51,18 @@ public enum Either<T, U>: EitherType, CustomDebugStringConvertible, CustomString
 			ifRight: transform)
 	}
 
+	/// Maps `Left` values with `transform`, and re-wraps `Right` values.
+	public func mapLeft<V>(@noescape transform: T -> V) -> Either<V, U> {
+		return flatMapLeft { .left(transform($0)) }
+	}
+
+	/// Returns the result of applying `transform` to `Left` values, or re-wrapping `Right` values.
+	public func flatMapLeft<V>(@noescape transform: T -> Either<V, U>) -> Either<V, U> {
+		return either(
+			ifLeft: transform,
+			ifRight: Either<V, U>.right)
+	}
+
 
 	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
 	public var left: T? {

--- a/EitherTests/EitherTests.swift
+++ b/EitherTests/EitherTests.swift
@@ -35,6 +35,19 @@ final class EitherTests: XCTestCase {
 	}
 
 
+	// MARK: - mapLeft
+
+	func testMapLeftIgnoresRightValues() {
+		let result = right.mapLeft(const("five")).either(ifLeft: id, ifRight: id)
+		XCTAssertEqual(result, "four")
+	}
+
+	func testMapLeftAppliesToLeftValues() {
+		let result = left.mapLeft(const("five")).either(ifLeft: id, ifRight: id)
+		XCTAssertEqual(result, "five")
+	}
+
+
 	// MARK: - >>-
 
 	func testFlatMapRetypesLeftValues() {


### PR DESCRIPTION
I also considered instead adding `swap` to turn `Either<T, U>` into `Either<U, T>` which makes `mapLeft(f)` equivalent to `swap.map(f).swap`. But that means that to use `flatMap` on a the left side you need a `T -> Either<U, V>` instead of `T -> Either<V, U>` 🤔