### PR TITLE
Change the naming again, and ...

### DIFF
--- a/Either.xcodeproj/project.pbxproj
+++ b/Either.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		D4C038A21A2BFF2300C262C7 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038A11A2BFF2300C262C7 /* EitherTests.swift */; };
 		D4C038B41A2C00BB00C262C7 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B31A2C00BB00C262C7 /* Either.swift */; };
 		D4C038B61A2C012000C262C7 /* EitherProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B51A2C012000C262C7 /* EitherProtocol.swift */; };
-		D4E7A7F11A2CCB800080A4DF /* EitherTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E7A7F01A2CCB800080A4DF /* EitherTypeTests.swift */; };
+		D4E7A7F11A2CCB800080A4DF /* EitherProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E7A7F01A2CCB800080A4DF /* EitherProtocolTests.swift */; };
 		D4EC3EF41A9457570080B23E /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC3EF21A9457570080B23E /* Prelude.framework */; };
 		D4EC3EF61A94576F0080B23E /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC3EF21A9457570080B23E /* Prelude.framework */; };
 		D4EC3EF81A94577B0080B23E /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC3EF21A9457570080B23E /* Prelude.framework */; };
@@ -57,7 +57,7 @@
 		D4C038A11A2BFF2300C262C7 /* EitherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		D4C038B31A2C00BB00C262C7 /* Either.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		D4C038B51A2C012000C262C7 /* EitherProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherProtocol.swift; sourceTree = "<group>"; };
-		D4E7A7F01A2CCB800080A4DF /* EitherTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTypeTests.swift; sourceTree = "<group>"; };
+		D4E7A7F01A2CCB800080A4DF /* EitherProtocolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherProtocolTests.swift; sourceTree = "<group>"; };
 		D4EC3EF21A9457570080B23E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8BB81FA1A939EA0001AA352 /* Either.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8BB82041A939EA0001AA352 /* Either-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Either-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -148,7 +148,7 @@
 			isa = PBXGroup;
 			children = (
 				D4C038A11A2BFF2300C262C7 /* EitherTests.swift */,
-				D4E7A7F01A2CCB800080A4DF /* EitherTypeTests.swift */,
+				D4E7A7F01A2CCB800080A4DF /* EitherProtocolTests.swift */,
 				D456ADDB1A944FBA002E3542 /* DisjunctionTests.swift */,
 				D4C0389F1A2BFF2300C262C7 /* Supporting Files */,
 			);
@@ -347,7 +347,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4E7A7F11A2CCB800080A4DF /* EitherTypeTests.swift in Sources */,
+				D4E7A7F11A2CCB800080A4DF /* EitherProtocolTests.swift in Sources */,
 				D4EC3EFC1A9457890080B23E /* DisjunctionTests.swift in Sources */,
 				D4C038A21A2BFF2300C262C7 /* EitherTests.swift in Sources */,
 			);

--- a/Either.xcodeproj/project.pbxproj
+++ b/Either.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		D4C0389B1A2BFF2300C262C7 /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4C0388F1A2BFF2300C262C7 /* Either.framework */; };
 		D4C038A21A2BFF2300C262C7 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038A11A2BFF2300C262C7 /* EitherTests.swift */; };
 		D4C038B41A2C00BB00C262C7 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B31A2C00BB00C262C7 /* Either.swift */; };
-		D4C038B61A2C012000C262C7 /* EitherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B51A2C012000C262C7 /* EitherType.swift */; };
+		D4C038B61A2C012000C262C7 /* EitherProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B51A2C012000C262C7 /* EitherProtocol.swift */; };
 		D4E7A7F11A2CCB800080A4DF /* EitherTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E7A7F01A2CCB800080A4DF /* EitherTypeTests.swift */; };
 		D4EC3EF41A9457570080B23E /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC3EF21A9457570080B23E /* Prelude.framework */; };
 		D4EC3EF61A94576F0080B23E /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4EC3EF21A9457570080B23E /* Prelude.framework */; };
@@ -25,7 +25,7 @@
 		F8BB82051A939EA0001AA352 /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BB81FA1A939EA0001AA352 /* Either.framework */; };
 		F8BB82161A939F57001AA352 /* Either.h in Headers */ = {isa = PBXBuildFile; fileRef = D4C038941A2BFF2300C262C7 /* Either.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F8BB82171A939F6C001AA352 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B31A2C00BB00C262C7 /* Either.swift */; };
-		F8BB82181A939F6C001AA352 /* EitherType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B51A2C012000C262C7 /* EitherType.swift */; };
+		F8BB82181A939F6C001AA352 /* EitherProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C038B51A2C012000C262C7 /* EitherProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,7 +56,7 @@
 		D4C038A01A2BFF2300C262C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D4C038A11A2BFF2300C262C7 /* EitherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		D4C038B31A2C00BB00C262C7 /* Either.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
-		D4C038B51A2C012000C262C7 /* EitherType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherType.swift; sourceTree = "<group>"; };
+		D4C038B51A2C012000C262C7 /* EitherProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherProtocol.swift; sourceTree = "<group>"; };
 		D4E7A7F01A2CCB800080A4DF /* EitherTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTypeTests.swift; sourceTree = "<group>"; };
 		D4EC3EF21A9457570080B23E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8BB81FA1A939EA0001AA352 /* Either.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,7 +127,7 @@
 			children = (
 				D4C038941A2BFF2300C262C7 /* Either.h */,
 				D4C038B31A2C00BB00C262C7 /* Either.swift */,
-				D4C038B51A2C012000C262C7 /* EitherType.swift */,
+				D4C038B51A2C012000C262C7 /* EitherProtocol.swift */,
 				D456ADD91A944DF4002E3542 /* Disjunction.swift */,
 				D4C038921A2BFF2300C262C7 /* Supporting Files */,
 			);
@@ -337,7 +337,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4C038B61A2C012000C262C7 /* EitherType.swift in Sources */,
+				D4C038B61A2C012000C262C7 /* EitherProtocol.swift in Sources */,
 				D4C038B41A2C00BB00C262C7 /* Either.swift in Sources */,
 				D456ADDA1A944DF4002E3542 /* Disjunction.swift in Sources */,
 			);
@@ -357,7 +357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8BB82181A939F6C001AA352 /* EitherType.swift in Sources */,
+				F8BB82181A939F6C001AA352 /* EitherProtocol.swift in Sources */,
 				F8BB82171A939F6C001AA352 /* Either.swift in Sources */,
 				D4EC3EFB1A9457840080B23E /* Disjunction.swift in Sources */,
 			);

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -15,14 +15,14 @@ public enum Either<T, U>: EitherProtocol, CustomDebugStringConvertible, CustomSt
 	/// Constructs a `Left`.
 	///
 	/// Suitable for partial application.
-	public static func with(left value: T) -> Either {
+	public static func toLeft(_ value: T) -> Either {
 		return .left(value)
 	}
 
 	/// Constructs a `Right`.
 	///
 	/// Suitable for partial application.
-	public static func with(right value: U) -> Either {
+	public static func toRight(_ value: U) -> Either {
 		return .right(value)
 	}
 

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -64,21 +64,6 @@ public enum Either<T, U>: EitherProtocol, CustomDebugStringConvertible, CustomSt
 	}
 
 
-	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
-	public var left: T? {
-		return either(
-			ifLeft: unit,
-			ifRight: const(nil))
-	}
-
-	/// Returns the value of `Right` instances, or `nil` for `Left` instances.
-	public var right: U? {
-		return either(
-			ifLeft: const(nil),
-			ifRight: unit)
-	}
-
-
 	/// Given equality functions for `T` and `U`, returns an equality function for `Either<T, U>`.
 	public static func equals(left: @escaping (T, T) -> Bool, right: @escaping (U, U) -> Bool) -> (Either<T, U>, Either<T, U>) -> Bool {
 		return { a, b in

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -64,16 +64,6 @@ public enum Either<T, U>: EitherProtocol, CustomDebugStringConvertible, CustomSt
 	}
 
 
-	/// Given equality functions for `T` and `U`, returns an equality function for `Either<T, U>`.
-	public static func equals(left: @escaping (T, T) -> Bool, right: @escaping (U, U) -> Bool) -> (Either<T, U>, Either<T, U>) -> Bool {
-		return { a, b in
-				(a.left &&& b.left).map(left)
-			??	(a.right &&& b.right).map(right)
-			??	false
-		}
-	}
-
-
 	// MARK: CustomDebugStringConvertible
 
 	public var debugDescription: String {

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -5,7 +5,7 @@
 /// By convention, and where applicable, `Left` is used to indicate failure, while `Right` is used to indicate success. (Mnemonic: “right” is a synonym for “correct.”)
 ///
 /// Otherwise, it is implied that `Left` and `Right` are effectively unordered alternatives of equal standing.
-public enum Either<T, U>: EitherType, CustomDebugStringConvertible, CustomStringConvertible {
+public enum Either<T, U>: EitherProtocol, CustomDebugStringConvertible, CustomStringConvertible {
 	case left(T)
 	case right(U)
 

--- a/Either/EitherProtocol.swift
+++ b/Either/EitherProtocol.swift
@@ -10,10 +10,10 @@ public protocol EitherProtocol {
 	associatedtype Right
 
 	/// Constructs a `Left` instance.
-	static func with(left: Left) -> Self
+	static func toLeft(_ value: Left) -> Self
 
 	/// Constructs a `Right` instance.
-	static func with(right: Right) -> Self
+	static func toRight(_ value: Right) -> Self
 
 	/// Returns the result of applying `f` to `Left` values, or `g` to `Right` values.
 	func either<Result>(ifLeft: (Left) throws -> Result, ifRight: (Right) throws -> Result) rethrows -> Result

--- a/Either/EitherProtocol.swift
+++ b/Either/EitherProtocol.swift
@@ -23,12 +23,22 @@ public protocol EitherProtocol {
 extension EitherProtocol {
 	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
 	public var left: Left? {
-		return either(ifLeft: unit, ifRight: const(nil))
+		return either(ifLeft: Optional<Left>.some, ifRight: const(nil))
 	}
 
 	/// Returns the value of `Right` instances, or `nil` for `Left` instances.
 	public var right: Right? {
-		return either(ifLeft: const(nil), ifRight: unit)
+		return either(ifLeft: const(nil), ifRight: Optional<Right>.some)
+	}
+	
+	/// Returns true of `Left` instances, or false for `Right` instances.
+	public var isLeft: Bool {
+		return either(ifLeft: const(true), ifRight: const(false))
+	}
+	
+	/// Returns true of `Right` instances, or false for `Left` instances.
+	public var isRight: Bool {
+		return either(ifLeft: const(false), ifRight: const(true))
 	}
 }
 

--- a/Either/EitherProtocol.swift
+++ b/Either/EitherProtocol.swift
@@ -35,10 +35,21 @@ extension EitherProtocol {
 
 // MARK: API
 
+extension EitherProtocol {
+	/// Given equivalent functions for `Left` and `Right`, returns an equivalent function for `EitherProtocol`.
+	public static func equivalence(left: @escaping (Left, Left) -> Bool, right: @escaping (Right, Right) -> Bool) -> (Self, Self) -> Bool {
+		return { a, b in
+			(a.left &&& b.left).map(left)
+				??	(a.right &&& b.right).map(right)
+				??	false
+		}
+	}
+}
+
 extension EitherProtocol where Left: Equatable, Right: Equatable {
 	/// Equality (tho not `Equatable`) over `EitherType` where `Left` & `Right` : `Equatable`.
 	public static func == (lhs: Self, rhs: Self) -> Bool {
-		return lhs.left == rhs.left && lhs.right == rhs.right
+		return Self.equivalence(left: ==, right: ==)(lhs, rhs)
 	}
 	
 	/// Inequality over `EitherType` where `Left` & `Right` : `Equatable`.

--- a/Either/EitherProtocol.swift
+++ b/Either/EitherProtocol.swift
@@ -5,29 +5,29 @@
 /// By convention, and where applicable, `Left` is used to indicate failure, while `Right` is to indicate success. (Mnemonic: “right is right,” i.e. “right” is a synonym for “correct.”)
 ///
 /// Otherwise it is implied that `Left` and `Right` are effectively unordered.
-public protocol EitherType {
-	associatedtype LeftType
-	associatedtype RightType
+public protocol EitherProtocol {
+	associatedtype Left
+	associatedtype Right
 
 	/// Constructs a `Left` instance.
-	static func with(left: LeftType) -> Self
+	static func with(left: Left) -> Self
 
 	/// Constructs a `Right` instance.
-	static func with(right: RightType) -> Self
+	static func with(right: Right) -> Self
 
 	/// Returns the result of applying `f` to `Left` values, or `g` to `Right` values.
-	func either<Result>(ifLeft: (LeftType) throws -> Result, ifRight: (RightType) throws -> Result) rethrows -> Result
+	func either<Result>(ifLeft: (Left) throws -> Result, ifRight: (Right) throws -> Result) rethrows -> Result
 }
 
 
-extension EitherType {
+extension EitherProtocol {
 	/// Returns the value of `Left` instances, or `nil` for `Right` instances.
-	public var left: LeftType? {
+	public var left: Left? {
 		return either(ifLeft: unit, ifRight: const(nil))
 	}
 
 	/// Returns the value of `Right` instances, or `nil` for `Left` instances.
-	public var right: RightType? {
+	public var right: Right? {
 		return either(ifLeft: const(nil), ifRight: unit)
 	}
 }
@@ -35,7 +35,7 @@ extension EitherType {
 
 // MARK: API
 
-extension EitherType where LeftType: Equatable, RightType: Equatable {
+extension EitherProtocol where Left: Equatable, Right: Equatable {
 	/// Equality (tho not `Equatable`) over `EitherType` where `Left` & `Right` : `Equatable`.
 	public static func == (lhs: Self, rhs: Self) -> Bool {
 		return lhs.left == rhs.left && lhs.right == rhs.right

--- a/EitherTests/EitherProtocolTests.swift
+++ b/EitherTests/EitherProtocolTests.swift
@@ -3,7 +3,7 @@
 import Either
 import XCTest
 
-final class EitherTypeTests: XCTestCase {
+final class EitherProtocolTests: XCTestCase {
 	func testEqualityOverLeft() {
 		XCTAssertTrue(Either<Int, Int>.left(1) == Either<Int, Int>.left(1))
 		XCTAssertFalse(Either<Int, Int>.left(1) == Either<Int, Int>.left(2))


### PR DESCRIPTION
### Change Point

1. Change the protocol name & associated type name to `EitherProtocol`, `Left`, `Right`.
1. Change the constructor name to `toLeft()`, `toRight()`. 
1. Remove computed property `left` & `right` in `Either`.
1. Move `equals` to `EitherProtocol` under the name of `equivalence`.
1. Add computed properties (`isLeft`, `isRight`)

----

#### 1. Change the protocol name & associated type name to `EitherProtocol`, `Left`, `Right`.

Because, name of `...Type` are not adopted in Swift3. And more simplicity.

#### 2. Change the constructor name to `toLeft()`, `toRight()`. 

I changed the constructor name to `with(left:)`, `with(right:)` in #45 . But, It forces a little complexity.

```swift
let x: Int? = 1
let either: Either<Int, Int>? = x.map{ Either.with(left: $0) }  // old
let either: Either<Int, Int>? = x.map(Either.toLeft)  // new
```
And, I think that it is more user-friendly name.

#### 3. Remove computed property `left` & `right` in `Either`.

Because these are already implemented in `EitherProtocol`.

#### 4. Move `equals` to `EitherProtocol` under the name of `equivalence`.

Type that conform to `EitherProtocol` will be able to express the equivalence.

```swift
struct A {
  let name: String
  ...
}
struct B: Equatable {... }
struct MyEither: EitherProtocol { 
  typealias Left: A
  typealias Right: B
  ... 
}

extension MyEither {
  static func == (lhs: Self, rhs: Self) -> Bool {
    return Self.equivalence(left: { $0.name == $1.name }, right: ==)(lhs, rhs)
  }
}
```

#### 5. Add computed properties (`isLeft`, `isRight`)

for convenient