### PR TITLE
Update Bind precedencegroup

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "robrix/Prelude" ~> 2.0.0
+github "robrix/Prelude" ~> 3.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "robrix/Prelude" "2.0.0"
+github "robrix/Prelude" "3.0.0"

--- a/Either.podspec
+++ b/Either.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.summary          = 'Swift µframework of Either, which represents two alternatives.'
   spec.source           = { :git => 'https://github.com/robrix/Either.git', :tag => spec.version.to_s }
   spec.source_files     = 'Either/*.swift'
-  spec.dependency       'Prelude', '~> 1.6.0'
+  spec.dependency       'Prelude', '~> 3.0.0'
   spec.requires_arc     = true
   spec.ios.deployment_target = "8.0"
   spec.osx.deployment_target = "10.9"

--- a/Either/Either.swift
+++ b/Either/Either.swift
@@ -102,7 +102,7 @@ precedencegroup Bind {
 	// Left-associativity so that chaining works like you’d expect, and for consistency with Haskell, Runes, swiftz, etc.
 	associativity: left
 	
-	higherThan: Application
+	higherThan: ForwardApplication
 	lowerThan: Composition
 }
 


### PR DESCRIPTION
I understand that `Bind` precedencegroup has left associativity and uses the new `ForwardApplication` precedencegroup for this purpose.