### PR TITLE
Use Optional.some instead of unit

### DIFF
--- a/EitherTests/DisjunctionTests.swift
+++ b/EitherTests/DisjunctionTests.swift
@@ -6,9 +6,9 @@ final class DisjunctionTests: XCTestCase {
 	}
 
 	func testAlternatesNonNilOperands() {
-		XCTAssert(((nil as Int?) ||| 1)?.either(ifLeft: unit, ifRight: unit) == 1)
-		XCTAssert((1 ||| (nil as Int?))?.either(ifLeft: unit, ifRight: unit) == 1)
-		XCTAssert((1 ||| 2)?.either(ifLeft: unit, ifRight: unit) == 1)
+		XCTAssert(((nil as Int?) ||| 1)?.either(ifLeft: Optional.some, ifRight: Optional.some) == 1)
+		XCTAssert((1 ||| (nil as Int?))?.either(ifLeft: Optional.some, ifRight: Optional.some) == 1)
+		XCTAssert((1 ||| 2)?.either(ifLeft: Optional.some, ifRight: Optional.some) == 1)
 		XCTAssert(((nil as Int?) ||| (nil as Int?)) == nil)
 	}
 
@@ -18,7 +18,7 @@ final class DisjunctionTests: XCTestCase {
 			effects += 1
 			return effects
 		}
-		XCTAssert((0 as Int? ||| right())?.either(ifLeft: unit, ifRight: unit) == 0)
+		XCTAssert((0 as Int? ||| right())?.either(ifLeft: Optional.some, ifRight: Optional.some) == 0)
 		XCTAssertEqual(effects, 0)
 	}
 }


### PR DESCRIPTION
Unit test fails because `unit` was removed from Prelude [3.0.0](https://github.com/robrix/Prelude/releases/tag/3.0.0).
I replaced `unit` with `Optional.some`.  Please review it 👯 