### PR TITLE
Update Prelude dependency to original repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "Prelude",
-        "repositoryURL": "https://github.com/nxtstep/Prelude.git",
+        "repositoryURL": "https://github.com/robrix/Prelude.git",
         "state": {
           "branch": null,
-          "revision": "1add7d8490e4d2bb1bb84ec4d025c0f700caec97",
+          "revision": "a048b7af84fc25a1fd0af62e1dfe34c685cd446f",
           "version": "3.0.1"
         }
       }


### PR DESCRIPTION
Since the latest release of [Prelude (3.0.1)](https://github.com/robrix/Prelude/releases/tag/3.0.1) we can now actually link the SwiftPM to the original repo.

When merged, maybe you can create a new release for this repo (Either) as well - so that people can actually use this repo address in their `Package.swift`. 🙏 

@335g, @guidomb, @nikita-leonov, @robb: Thanks for your consideration